### PR TITLE
Fix `library/fbctf` image not found error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ memcached:
   image: memcached
 fbctf:
   restart: always
-  image: fbctf
+  image: alexgaspar/fbctf
   links:
     - memcached:memcached
     - mysql:mysql


### PR DESCRIPTION
Running `docker-compose up` errors with

```
ERROR: Error: image library/fbctf not found
```

Specifying the full image name fixes that.
