### PR TITLE
(Feat): Resolves Issue #11

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,228 @@
-mysql:
-  restart: always
-  image: mysql:5.5
-  environment:
-    - MYSQL_ROOT_PASSWORD=root
-    - MYSQL_DATABASE=fbctf
-    - MYSQL_USER=fbctf
-    - MYSQL_PASSWORD=fbctf
-memcached:
-  restart: always
-  image: memcached
-fbctf:
-  restart: always
-  image: alexgaspar/fbctf
-  links:
-    - memcached:memcached
-    - mysql:mysql
-  environment:
-    - MYSQL_HOST=mysql
-    - MYSQL_PORT=3306
-    - MYSQL_DATABASE=fbctf
-    - MYSQL_USER=fbctf
-    - MYSQL_PASSWORD=fbctf
-    - MEMCACHED_PORT=11211
-    - SSL_SELF_SIGNED=true
-  ports:
-    - "80:80"
-    - "443:443"
+---
+version: "3.6"
+
+services:
+
+  autoscale:
+    image: gianarb/orbiter:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      DOCKER_HOST: unix:///var/run/docker.sock
+    ports:
+      - target: 8000
+        protocol: "tcp"
+        mode: "ingress"
+    deploy:
+      restart_policy:
+        condition: on-failure
+      mode: replicated
+      replicas: 1
+      labels:
+        com.centurylinklabs.watchtower.enable: "true"
+        orbiter: "false"
+        traefik.enable: "true"
+        traefik.port: 8000
+        traefik.network: public
+        traefik.frontend.priority: 10
+        traefik.frontend.rule: 'Host:scaler.$(VIRTUAL_HOST)'
+        traefik.backend: "scaler"
+      placement:
+        constraints: [node.role == manager]
+    networks:
+      - public
+
+  watchtower:
+    image: 'v2tec/watchtower:latest'
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: --label-enable --interval 30 --cleanup
+    deploy:
+      restart_policy:
+        condition: on-failure
+      mode: replicated
+      replicas: 1
+      labels:
+        com.centurylinklabs.watchtower.enable: "true"
+        traefik.enable: "false"
+      placement:
+        constraints: [node.role == manager]
+
+  traefik:
+    image: traefik:1.5
+    command: --web --docker --docker.swarmmode --docker.watch --docker.domain=local --logLevel=DEBUG --api
+    deploy:
+      placement:
+        constraints: [node.role==manager]
+      restart_policy:
+        condition: on-failure
+      labels:
+        traefik.port: "8080"
+        traefik.docker.network: "public"
+        traefik.frontend.rule: "Host:traefik.$(VIRTUAL_HOST)"
+        traefik.entryPoints.http.redirect: "https"
+    ports:
+      - target: 443
+        published: 443
+        protocol: "tcp"
+        mode: "ingress"
+      - target: 80
+        published: 80
+        protocol: "tcp"
+        mode: "ingress"
+      - target: 8080
+        published: 8080
+        protocol: "tcp"
+        mode: "host"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /dev/null:/traefik.toml
+    networks:
+      public:
+        aliases:
+          - gateway
+ 
+  mysql:
+    ports:
+      - target: 3306
+        protocol: tcp
+        mode: "ingress"
+    image: mysql:5.7
+    environment:
+      - MYSQL_ROOT_PASSWORD=$(MYSQL_ROOT_PASSWORD)
+      - MYSQL_DATABASE=fbctf
+      - MYSQL_USER=$(MYSQL_USER)
+      - MYSQL_PASSWORD=$(MYSQL_PASSWORD)
+    networks:
+      default:
+        aliases:
+          - mysql
+          - db
+    deploy:
+      restart_policy: 
+        condition: on-failure
+      replicas: 1
+      mode: replicated
+      labels:
+        com.centurylinklabs.watchtower.enable: "true"
+        orbiter: "false"
+        traefik.enable: "false"
+
+  # optional       
+  adminer:
+    image: adminer
+    ports:
+      - target: 8080
+        protocol: tcp
+        mode: "ingress"
+    hostname: "dbpanel.local"
+    networks:
+      - public
+      - default
+    depends_on:
+      - mysql
+    deploy:
+      restart_policy:
+        condition: on-failure
+      mode: replicated
+      replicas: 1
+      labels:
+        com.centurylinklabs.watchtower.enable: "true"
+        orbiter: "true"
+        orbiter.up: 3
+        orbiter.down: 1
+        traefik.enable: "true"
+        traefik.port: 8080
+        traefik.docker.network: "public"
+        traefik.backend.loadbalancer.stickiness: "true"
+        traefik.backend.loadbalancer.swarm: "true"
+        traefik.frontend.rule: "Host:dbpanel.$(VIRTUAL_HOST)"
+        traefik.frontend.proto: "http"
+        traefik.frontend.entrypoints: "http"
+        traefik.frontend.priority: 10
+
+  memcached:
+    ports:
+      - target: 11211
+        protocol: tcp
+        mode: "ingress"
+    image: memcached:latest
+    deploy:
+      restart_policy:
+       condition: on-failure
+      replicas: 1
+      mode: replicated
+      labels:
+        com.centurylinklabs.watchtower.enable: "true"
+        orbiter: "false"
+        traefik.enable: "false"
+    networks:
+      default:
+        aliases:
+          - memcached
+
+  fbctf:
+    image: alexgaspar/fbctf:latest
+    ports:
+      - target: 80
+        protocol: tcp
+        mode: "ingress"
+      - target: 443
+        protocol: tcp
+        mode: "ingress"
+    environment:
+      - MYSQL_HOST=mysql
+      - MYSQL_PORT=3306
+      - MYSQL_ROOT_PASSWORD=$(MYSQL_ROOT_PASSWORD)
+      - MYSQL_DATABASE=fbctf
+      - MYSQL_USER=$(MYSQL_USER)
+      - MYSQL_PASSWORD=$(MYSQL_PASSWORD)
+      - MEMCACHED_PORT=11211
+      - CTF_URL=$(VIRTUAL_HOST)
+      - SSL_SELF_SIGNED=false
+    hostname: "$(VIRTUAL_HOST)"
+    networks:
+      - public
+      - default
+    depends_on:
+      - memcached
+      - mysql
+    deploy:
+      restart_policy:
+        condition: on-failure
+      mode: replicated
+      replicas: 1
+      labels:
+        com.centurylinklabs.watchtower.enable: "true"
+        orbiter: "true"
+        orbiter.up: 3
+        orbiter.down: 1
+        traefik.enable: "true"
+        traefik.port: 80
+        traefik.docker.network: "public"
+        traefik.backend.loadbalancer.stickiness: "true"
+        traefik.backend.loadbalancer.swarm: "true"
+        traefik.frontend.rule: "Host:$(VIRTUAL_HOST),www.$(VIRTUAL_HOST)"
+        traefik.frontend.proto: "http"
+        traefik.frontend.entrypoints: "http"
+        traefik.frontend.priority: 10
+        traefik.frontend.passTLSCert: "false"
+        traefik.frontend.passHostHeader: "true"
+        traefik.frontend.headers.SSLProxyHeaders: "X-Forwarded-For:https"
+        traefik.frontend.headers.forceSTSHeader: "true"
+        traefik.frontend.headers.STSSeconds: "315360000"
+        traefik.frontend.headers.STSIncludeSubdomains: "true"
+        traefik.frontend.headers.STSPreload: "true"
+        traefik.frontend.headers.browserXSSFilter: "true"
+        traefik.frontend.headers.contentTypeNosniff: "true"
+        traefik.frontend.headers.customrequestheaders: "X-Forwarded-Ssl:on"
+
+networks:
+  public:
+    driver: "overlay"
+    scope: "swarm"
+
+  default:
+    driver: "overlay"
+...
+# vim: set sts=2 sw=2 ts=2 et ai:


### PR DESCRIPTION
Implements #11 

Requires the following env variables to be set at deployment:
|||
|-|-|
|VIRTUAL_HOST| (domain)  - Top level domain of the virtual host|
|MYSQL_USER| (string) - User created for fbctf |
|MYSQL_ROOT_PASSWORD| (string) random string for mysql root user password |
|MYSQL_PASSWORD| (string) random string for mysql root user password |

If one hits the swarm cluster master with the following host names they will get additional services:

|||
|-|-|
|scaler.$(VIRTUAL_HOST)|autoscaler rest service that uses POST to scale up or down from one's monitoring system or curl|
|traefik.$(VIRTUAL_HOST)|dashboard for seeing routing and metrics|
|dbpanel.$(VIRTUAL_HOST)|admin panel for mysql|
|$(VIRTUAL_HOST) or www.$(VIRTUAL_HOST)| the FB CTF service |